### PR TITLE
Add agentic development workflow: red/green TDD, skills-as-config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,5 @@ All development decisions should be evaluated against these principles (detailed
 - The data input protocol in AGENTS.md is authoritative — follow the exact dispatch order
 - Error messages should be specific and actionable (e.g., "field 'legend.position' must be one of [top, bottom, left, right], got 'outside'")
 - WCAG contrast checks are structural gates (errors, not warnings)
+- Follow red/green TDD for all features and fixes — write tests first, confirm they fail, then implement. See "Agentic Development Workflow" in AGENTS.md.
+- Treat recipes in AGENTS.md (geom recipe, contribution patterns) as agent-executable skills — follow them as step-by-step instructions, not just reference docs. The codebase is small enough (~4000 lines) to read and understand in full.


### PR DESCRIPTION
## Summary

- **New "Agentic Development Workflow" section in AGENTS.md** with three subsections: red/green TDD (Willison), experimentation-is-cheap (Willison), and recipes-as-skills (Karpathy's observation on the Claw ecosystem)
- **Restructured geom recipe** from 5 steps to 7 steps following red/green TDD — tests are now Steps 1-2 (write tests, confirm they fail), implementation is Steps 3-5, and verification is Steps 6-7 (confirm tests pass, run full gate). Includes a complete copy-paste test template.
- **Updated "Tests travel with code" bullet** in Contribution Conventions to specify red/green ordering in commit history
- **CLAUDE.md**: two bullets added (red/green TDD, recipes-as-skills)
- **docs/docs/contributing.md**: geom recipe synced with AGENTS.md's new 7-step structure

## Context

Simon Willison's "Code is Cheap Now" and "Red/Green TDD" guides identify two agentic engineering patterns directly relevant to botplotlib: experiment freely but gate ruthlessly, and always start with a failing test. Andrej Karpathy's observations on NanoClaw identify a third: recipes/skills as configuration instead of config files. All three align with existing project philosophy (structural quality gates, proposal/execution split, cyborg social contract) — this PR makes the alignment explicit in contributor docs.

## Test plan

- [x] `uv run ruff check .` — all passed
- [x] `uv run black --check .` — all 66 files unchanged
- [x] `cd docs && uv run --group docs mkdocs build --strict` — builds successfully
- [x] `uv run pytest` — 389 passed
- [x] Documentation-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)