### PR TITLE
Rename import alias bpl → blt

### DIFF
--- a/.skills/matplotlib-refactor/SKILL.md
+++ b/.skills/matplotlib-refactor/SKILL.md
@@ -18,12 +18,12 @@ User has a matplotlib script they want to convert to botplotlib.
 
 | Matplotlib | botplotlib |
 |---|---|
-| `plt.scatter(x, y)` | `bpl.scatter(data, x="x", y="y")` |
-| `plt.plot(x, y)` | `bpl.line(data, x="x", y="y")` |
-| `plt.bar(x, y)` | `bpl.bar(data, x="x", y="y")` |
-| `ax.scatter(x, y)` | `bpl.scatter(data, x="x", y="y")` |
-| `ax.plot(x, y)` | `bpl.line(data, x="x", y="y")` |
-| `ax.bar(x, y)` | `bpl.bar(data, x="x", y="y")` |
+| `plt.scatter(x, y)` | `blt.scatter(data, x="x", y="y")` |
+| `plt.plot(x, y)` | `blt.line(data, x="x", y="y")` |
+| `plt.bar(x, y)` | `blt.bar(data, x="x", y="y")` |
+| `ax.scatter(x, y)` | `blt.scatter(data, x="x", y="y")` |
+| `ax.plot(x, y)` | `blt.line(data, x="x", y="y")` |
+| `ax.bar(x, y)` | `blt.bar(data, x="x", y="y")` |
 | `plt.title("...")` | `title="..."` parameter |
 | `plt.xlabel("...")` | `x_label="..."` parameter |
 
@@ -44,8 +44,8 @@ plt.show()
 ''')
 
 # Render the converted spec
-import botplotlib as bpl
-fig = bpl.render(spec)
+import botplotlib as blt
+fig = blt.render(spec)
 fig.save_svg("migrated.svg")
 ```
 

--- a/.skills/spec-generation/SKILL.md
+++ b/.skills/spec-generation/SKILL.md
@@ -19,16 +19,16 @@ User provides a description of what they want to plot and optionally their data.
 User: "Make a scatter plot of weight vs mpg, colored by origin"
 
 ```python
-import botplotlib as bpl
+import botplotlib as blt
 
-fig = bpl.scatter(data, x="weight", y="mpg", color="origin",
+fig = blt.scatter(data, x="weight", y="mpg", color="origin",
                   title="Fuel Efficiency by Weight")
 fig.save_svg("plot.svg")
 ```
 
 ## Constraints
 
-- Always use the flat API (`bpl.scatter`, `bpl.line`, `bpl.bar`)
+- Always use the flat API (`blt.scatter`, `blt.line`, `blt.bar`)
 - Default to the `"default"` theme unless the user specifies otherwise
 - Include a title if the user's description implies one
 - Set axis labels based on column names unless the user specifies alternatives

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ The PlotSpec is the universal boundary layer. Everything must become a PlotSpec 
 
 ```
 [Human / Python path]                    [Agent / JSON path]
-bpl.scatter(data, x="a", y="b")         LLM generates PlotSpec JSON directly
+blt.scatter(data, x="a", y="b")         LLM generates PlotSpec JSON directly
         │                                        │
         └──────────> PlotSpec <──────────────────┘
               (Pydantic model, JSON-serializable)
@@ -150,7 +150,7 @@ from __future__ import annotations
 
 import pytest
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.compiler.compiler import compile_spec
 from botplotlib.geoms import get_geom, registered_geoms
 from botplotlib.spec.models import DataSpec, LayerSpec, PlotSpec
@@ -173,15 +173,15 @@ class TestYourGeomRegistry:
 
 
 class TestYourGeomAPI:
-    """bpl.yourgeom() convenience function works."""
+    """blt.yourgeom() convenience function works."""
 
     def test_basic_render(self) -> None:
-        fig = bpl.yourgeom(SAMPLE_DATA, x="x_col", y="y_col")
+        fig = blt.yourgeom(SAMPLE_DATA, x="x_col", y="y_col")
         svg = fig.to_svg()
         assert "<svg" in svg and "</svg>" in svg
 
     def test_with_title(self) -> None:
-        fig = bpl.yourgeom(SAMPLE_DATA, x="x_col", y="y_col", title="Test")
+        fig = blt.yourgeom(SAMPLE_DATA, x="x_col", y="y_col", title="Test")
         assert "Test" in fig.to_svg()
 
 
@@ -225,7 +225,7 @@ class TestYourGeomEdgeCases:
 
     def test_single_data_point(self) -> None:
         data = {"x_col": ["A"], "y_col": [42]}
-        fig = bpl.yourgeom(data, x="x_col", y="y_col")
+        fig = blt.yourgeom(data, x="x_col", y="y_col")
         assert "<svg" in fig.to_svg()
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Matplotlib has fed the scientific Python community for two decades. botplotlib i
 </p>
 
 - **Beautiful by default** — themes designed so the first render is more often the final render
-- **Lightweight** — `bpl.scatter(data, x="a", y="b")` and you're done
+- **Lightweight** — `blt.scatter(data, x="a", y="b")` and you're done
 - **Token-efficient** — 1 line instead of 15. Fewer tokens, fewer places to go wrong
 
 Botplotlib is also an experiment in cyborg-source. What does open-source collaboration look like when some of the collaborators are AI? We don't know but we put a bunch of ideas in [GOVERNANCE.md](GOVERNANCE.md). It is wildly over-engineered for our current contributor count. 
@@ -28,13 +28,13 @@ For the full architecture overview, design principles, and module map, see [AGEN
 ## Quick example
 
 ```python
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "layer": ["bottom bun", "lettuce", "bot", "tomato", "top bun"],
     "size": [1, 1, 1, 1, 1],
 }
-fig = bpl.bar(
+fig = blt.bar(
     data, x="layer", y="size", color="layer",
     color_map={"bottom bun": "#B07830", "lettuce": "#388E3C",
                "bot": "#4E79A7", "tomato": "#E53935",

--- a/botplotlib/figure.py
+++ b/botplotlib/figure.py
@@ -17,7 +17,7 @@ class Figure:
     """A rendered plot that can be saved, displayed, or inspected.
 
     Typically created via the convenience functions in ``botplotlib._api``
-    (e.g., ``bpl.scatter()``, ``bpl.line()``, ``bpl.bar()``).
+    (e.g., ``blt.scatter()``, ``blt.line()``, ``blt.bar()``).
 
     Agent / JSON path:
         ``Figure.from_json(json_string)`` — parse a PlotSpec JSON string.

--- a/botplotlib/refactor/from_matplotlib.py
+++ b/botplotlib/refactor/from_matplotlib.py
@@ -128,7 +128,7 @@ def to_botplotlib_code(source: str | Path) -> str:
         Python code using botplotlib that produces the equivalent plot.
     """
     spec = from_matplotlib(source)
-    lines = ["import botplotlib as bpl", ""]
+    lines = ["import botplotlib as blt", ""]
 
     if not spec.layers:
         lines.append("# No plot calls detected in the matplotlib script")
@@ -148,7 +148,7 @@ def to_botplotlib_code(source: str | Path) -> str:
     if len(spec.layers) == 1:
         layer = spec.layers[0]
         func = layer.geom  # scatter, line, bar
-        parts = [f'bpl.{func}(data, x="{layer.x}", y="{layer.y}"']
+        parts = [f'blt.{func}(data, x="{layer.x}", y="{layer.y}"']
 
         if spec.labels.title:
             parts.append(f', title="{spec.labels.title}"')
@@ -165,12 +165,12 @@ def to_botplotlib_code(source: str | Path) -> str:
         lines.append("".join(parts))
     else:
         # Multi-layer: use Figure directly
-        lines.append("spec = bpl.PlotSpec(")
-        lines.append("    data=bpl.spec.models.DataSpec(columns=data),")
+        lines.append("spec = blt.PlotSpec(")
+        lines.append("    data=blt.spec.models.DataSpec(columns=data),")
         lines.append("    layers=[")
         for layer in spec.layers:
             lines.append(
-                f'        bpl.spec.models.LayerSpec(geom="{layer.geom}", '
+                f'        blt.spec.models.LayerSpec(geom="{layer.geom}", '
                 f'x="{layer.x}", y="{layer.y}"),'
             )
         lines.append("    ],")
@@ -179,11 +179,11 @@ def to_botplotlib_code(source: str | Path) -> str:
             x_str = f'"{spec.labels.x}"' if spec.labels.x else "None"
             y_str = f'"{spec.labels.y}"' if spec.labels.y else "None"
             lines.append(
-                f"    labels=bpl.spec.models.LabelsSpec("
+                f"    labels=blt.spec.models.LabelsSpec("
                 f"title={title_str}, x={x_str}, y={y_str}),"
             )
         lines.append(")")
-        lines.append("fig = bpl.render(spec)")
+        lines.append("fig = blt.render(spec)")
 
     # Add save call if savefig was detected
     if hasattr(spec, "_refactor_metadata"):

--- a/docs/docs/guide.md
+++ b/docs/docs/guide.md
@@ -3,13 +3,13 @@
 ## Quick example
 
 ```python
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "layer": ["bottom bun", "lettuce", "bot", "tomato", "top bun"],
     "size": [1, 1, 1, 1, 1],
 }
-fig = bpl.bar(
+fig = blt.bar(
     data, x="layer", y="size", color="layer",
     color_map={"bottom bun": "#B07830", "lettuce": "#388E3C",
                "bot": "#4E79A7", "tomato": "#E53935",
@@ -33,7 +33,7 @@ fig.save_svg("plot.svg")
 All theme palettes enforce WCAG AA contrast ratios (>= 3:1 against white). This is a compiler error, not a warning. You literally cannot ship inaccessible colors because [accountability lives in systems](https://estsjournal.org/index.php/ests/article/view/260).   
 
 ```python
-import botplotlib as bpl
+import botplotlib as blt
 
 years = list(range(2011, 2026))
 data = {
@@ -49,7 +49,7 @@ These Data are from [Nathan's Famous Hot Dog Eating Contest](https://en.wikipedi
 ### Default
 
 ```python
-fig = bpl.line(data, x="year", y="hot_dogs", color="division",
+fig = blt.line(data, x="year", y="hot_dogs", color="division",
                title="Nathan's Hot Dog Eating Contest",
                x_label="Year", y_label="Hot Dogs Eaten")
 ```
@@ -59,7 +59,7 @@ fig = bpl.line(data, x="year", y="hot_dogs", color="division",
 ### Bluesky
 
 ```python
-fig = bpl.line(data, x="year", y="hot_dogs", color="division",
+fig = blt.line(data, x="year", y="hot_dogs", color="division",
                title="Nathan's Hot Dog Eating Contest",
                x_label="Year", y_label="Hot Dogs Eaten",
                theme="bluesky")
@@ -70,7 +70,7 @@ fig = bpl.line(data, x="year", y="hot_dogs", color="division",
 ### PDF
 
 ```python
-fig = bpl.line(data, x="year", y="hot_dogs", color="division",
+fig = blt.line(data, x="year", y="hot_dogs", color="division",
                title="Nathan's Hot Dog Eating Contest",
                x_label="Year", y_label="Hot Dogs Eaten",
                theme="pdf")
@@ -81,7 +81,7 @@ fig = bpl.line(data, x="year", y="hot_dogs", color="division",
 ### Print
 
 ```python
-fig = bpl.line(data, x="year", y="hot_dogs", color="division",
+fig = blt.line(data, x="year", y="hot_dogs", color="division",
                title="Nathan's Hot Dog Eating Contest",
                x_label="Year", y_label="Hot Dogs Eaten",
                theme="print")
@@ -92,7 +92,7 @@ fig = bpl.line(data, x="year", y="hot_dogs", color="division",
 ### Magazine
 
 ```python
-fig = bpl.line(data, x="year", y="hot_dogs", color="division",
+fig = blt.line(data, x="year", y="hot_dogs", color="division",
                title="Nathan's Hot Dog Eating Contest",
                x_label="Year", y_label="Hot Dogs Eaten",
                theme="magazine")
@@ -191,9 +191,9 @@ print(bpl_code)
 Output:
 
 ```python
-import botplotlib as bpl
+import botplotlib as blt
 
-fig = bpl.scatter(
+fig = blt.scatter(
     {"x": [0, 1, 2, 3, 4, 5], "y": [0, 1, 4, 9, 16, 25]},
     x="x",
     y="y",
@@ -208,9 +208,9 @@ You can also extract a `PlotSpec` directly:
 
 ```python
 from botplotlib.refactor import from_matplotlib
-import botplotlib as bpl
+import botplotlib as blt
 
 spec = from_matplotlib("my_old_script.py")
-fig = bpl.render(spec)
+fig = blt.render(spec)
 fig.save_svg("migrated.svg")
 ```

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -4,7 +4,7 @@ import math
 import random
 from pathlib import Path
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.refactor import from_matplotlib
 
 OUT = Path(__file__).parent / "docs" / "assets" / "examples"
@@ -15,7 +15,7 @@ random.seed(42)
 # ── Getting Started ──────────────────────────────────────────────────────
 
 # Basic scatter
-bpl.scatter(
+blt.scatter(
     {"x": [1, 2, 3, 4, 5], "y": [2, 4, 3, 7, 5]},
     x="x",
     y="y",
@@ -23,7 +23,7 @@ bpl.scatter(
 ).save_svg(OUT / "gs_basic_scatter.svg")
 
 # Grouped scatter
-bpl.scatter(
+blt.scatter(
     {
         "weight": [2.5, 3.0, 3.5, 4.0, 4.5],
         "mpg": [30, 28, 25, 22, 20],
@@ -45,7 +45,7 @@ weights = [2.0 + random.gauss(0, 0.6) for _ in range(n)]
 mpg = [45 - 8 * w + random.gauss(0, 2.5) for w in weights]
 origins = random.choices(["USA", "Europe", "Japan"], weights=[4, 3, 3], k=n)
 
-bpl.scatter(
+blt.scatter(
     {"weight": weights, "mpg": mpg, "origin": origins},
     x="weight",
     y="mpg",
@@ -57,7 +57,7 @@ bpl.scatter(
 
 # Line
 months = list(range(1, 13))
-bpl.line(
+blt.line(
     {
         "month": months * 2,
         "revenue": [
@@ -97,7 +97,7 @@ bpl.line(
 ).save_svg(OUT / "pt_line.svg")
 
 # Bar
-bpl.bar(
+blt.bar(
     {
         "language": ["Python", "JavaScript", "TypeScript", "Rust", "Go", "Java"],
         "score": [92, 78, 71, 54, 48, 45],
@@ -110,7 +110,7 @@ bpl.bar(
 ).save_svg(OUT / "pt_bar.svg")
 
 # Waterfall
-bpl.waterfall(
+blt.waterfall(
     {
         "category": ["Revenue", "COGS", "Gross Profit", "OpEx", "Tax", "Net Income"],
         "amount": [500, -200, 300, -150, -45, 105],
@@ -124,7 +124,7 @@ bpl.waterfall(
 
 # Layered
 fig_layered = (
-    bpl.plot(
+    blt.plot(
         {
             "year": [2019, 2020, 2021, 2022, 2023, 2024],
             "actual": [4.2, 3.8, 5.1, 6.3, 7.0, 8.2],
@@ -147,7 +147,7 @@ wave_data = {
 }
 
 for theme_name in ("default", "bluesky", "pdf", "print", "magazine"):
-    bpl.line(
+    blt.line(
         wave_data,
         x="x",
         y="y",
@@ -158,7 +158,7 @@ for theme_name in ("default", "bluesky", "pdf", "print", "magazine"):
 
 # ── JSON Path ────────────────────────────────────────────────────────────
 
-bpl.Figure.from_dict(
+blt.Figure.from_dict(
     {
         "data": {"columns": {"x": [1, 2, 3, 4, 5], "y": [1, 4, 9, 16, 25]}},
         "layers": [{"geom": "scatter", "x": "x", "y": "y"}],
@@ -167,7 +167,7 @@ bpl.Figure.from_dict(
     }
 ).save_svg(OUT / "json_from_dict.svg")
 
-bpl.Figure.from_dict(
+blt.Figure.from_dict(
     {
         "data": {
             "columns": {
@@ -181,7 +181,7 @@ bpl.Figure.from_dict(
     }
 ).save_svg(OUT / "json_from_dict_line.svg")
 
-spec = bpl.PlotSpec.model_validate(
+spec = blt.PlotSpec.model_validate(
     {
         "data": {"columns": {"x": [1, 2, 3], "y": [1, 4, 9]}},
         "layers": [{"geom": "line", "x": "x", "y": "y"}],
@@ -189,7 +189,7 @@ spec = bpl.PlotSpec.model_validate(
         "theme": "bluesky",
     }
 )
-bpl.render(spec).save_svg(OUT / "json_render.svg")
+blt.render(spec).save_svg(OUT / "json_render.svg")
 
 # ── Refactoring ──────────────────────────────────────────────────────────
 
@@ -207,7 +207,7 @@ plt.show()
 """
 
 spec = from_matplotlib(mpl_code)
-bpl.render(spec).save_svg(OUT / "refactor_scatter.svg")
+blt.render(spec).save_svg(OUT / "refactor_scatter.svg")
 
 mpl_code2 = """\
 import matplotlib.pyplot as plt
@@ -224,7 +224,7 @@ plt.savefig("old_plot.png")
 """
 
 spec2 = from_matplotlib(mpl_code2)
-bpl.render(spec2).save_svg(OUT / "refactor_squared.svg")
+blt.render(spec2).save_svg(OUT / "refactor_squared.svg")
 
 # ── Gallery: theme showcase (Nathan's Hot Dog Eating Contest) ────────────
 
@@ -267,7 +267,7 @@ gallery_data = {
 }
 
 for theme_name in ("default", "bluesky", "pdf", "print", "magazine"):
-    bpl.line(
+    blt.line(
         gallery_data,
         x="year",
         y="hot_dogs",
@@ -285,7 +285,7 @@ bar_data = {
 }
 
 for theme_name in ("default", "magazine"):
-    bpl.bar(
+    blt.bar(
         bar_data,
         x="year",
         y="hot_dogs",

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -25,9 +25,9 @@ def _(mo):
 
 @app.cell
 def _():
-    import botplotlib as bpl
+    import botplotlib as blt
 
-    return (bpl,)
+    return (blt,)
 
 
 @app.cell(hide_code=True)
@@ -60,8 +60,8 @@ def _():
 
 
 @app.cell
-def _(bpl, gallery_line, gallery_scatter, mo):
-    _fig_s = bpl.scatter(
+def _(blt, gallery_line, gallery_scatter, mo):
+    _fig_s = blt.scatter(
         gallery_scatter,
         x="weight",
         y="mpg",
@@ -72,7 +72,7 @@ def _(bpl, gallery_line, gallery_scatter, mo):
         width=350,
         height=250,
     )
-    _fig_l = bpl.line(
+    _fig_l = blt.line(
         gallery_line,
         x="month",
         y="revenue",
@@ -83,7 +83,7 @@ def _(bpl, gallery_line, gallery_scatter, mo):
         width=350,
         height=250,
     )
-    _fig_b = bpl.bar(
+    _fig_b = blt.bar(
         {
             "language": [
                 "Python",
@@ -126,8 +126,8 @@ def _(mo):
 
 
 @app.cell
-def _(bpl):
-    bpl.scatter(
+def _(blt):
+    blt.scatter(
         {"x": [1, 2, 3, 4, 5], "y": [2, 4, 3, 7, 5]},
         x="x",
         y="y",
@@ -139,7 +139,7 @@ def _(bpl):
 
 
 @app.cell
-def _(bpl, random):
+def _(blt, random):
     random.seed(42)
     _n = 27  # points per cluster
     scatter_data = {"x": [], "y": [], "group": []}
@@ -153,7 +153,7 @@ def _(bpl, random):
             scatter_data["y"].append(round(random.gauss(_cy, 1.0), 1))
             scatter_data["group"].append(_name)
 
-    fig_scatter = bpl.scatter(
+    fig_scatter = blt.scatter(
         scatter_data,
         x="x",
         y="y",
@@ -173,14 +173,14 @@ def _(mo):
     mo.md(r"""
     ## Line and Bar Charts
 
-    Same API, different geometries. `bpl.line()` and `bpl.bar()` use the
-    same signature as `bpl.scatter()`.
+    Same API, different geometries. `blt.line()` and `blt.bar()` use the
+    same signature as `blt.scatter()`.
     """)
     return
 
 
 @app.cell
-def _(bpl):
+def _(blt):
     _months = list(range(1, 13))
     revenue_data = {
         "month": _months * 3,
@@ -191,7 +191,7 @@ def _(bpl):
         ),
         "segment": ["SaaS"] * 12 + ["Hardware"] * 12 + ["Services"] * 12,
     }
-    fig_line = bpl.line(
+    fig_line = blt.line(
         revenue_data,
         x="month",
         y="revenue",
@@ -207,8 +207,8 @@ def _(bpl):
 
 
 @app.cell
-def _(bpl):
-    fig_bar = bpl.bar(
+def _(blt):
+    fig_bar = blt.bar(
         {
             "language": [
                 "Python",
@@ -245,7 +245,7 @@ def _(mo):
 
 
 @app.cell
-def _(bpl):
+def _(blt):
     records = [
         {"language": "Python", "popularity": 30},
         {"language": "JavaScript", "popularity": 25},
@@ -254,7 +254,7 @@ def _(bpl):
         {"language": "Go", "popularity": 9},
         {"language": "Java", "popularity": 8},
     ]
-    fig_records = bpl.bar(
+    fig_records = blt.bar(
         records,
         x="language",
         y="popularity",
@@ -269,9 +269,9 @@ def _(bpl):
 
 
 @app.cell
-def _(bpl):
+def _(blt):
     fig_layered = (
-        bpl.plot(
+        blt.plot(
             {
                 "year": [2019, 2020, 2021, 2022, 2023, 2024],
                 "actual": [4.2, 3.8, 5.1, 6.3, 7.0, 8.2],
@@ -320,8 +320,8 @@ def _():
 
 
 @app.cell
-def _(bpl, mo, wave_data):
-    fig_default = bpl.line(
+def _(blt, mo, wave_data):
+    fig_default = blt.line(
         wave_data,
         x="x",
         y="y",
@@ -330,7 +330,7 @@ def _(bpl, mo, wave_data):
         width=400,
         height=280,
     )
-    fig_bluesky = bpl.line(
+    fig_bluesky = blt.line(
         wave_data,
         x="x",
         y="y",
@@ -345,8 +345,8 @@ def _(bpl, mo, wave_data):
 
 
 @app.cell
-def _(bpl, mo, wave_data):
-    fig_magazine = bpl.line(
+def _(blt, mo, wave_data):
+    fig_magazine = blt.line(
         wave_data,
         x="x",
         y="y",
@@ -356,7 +356,7 @@ def _(bpl, mo, wave_data):
         width=400,
         height=280,
     )
-    fig_pdf = bpl.line(
+    fig_pdf = blt.line(
         wave_data,
         x="x",
         y="y",
@@ -371,8 +371,8 @@ def _(bpl, mo, wave_data):
 
 
 @app.cell
-def _(bpl, mo, wave_data):
-    fig_print = bpl.line(
+def _(blt, mo, wave_data):
+    fig_print = blt.line(
         wave_data,
         x="x",
         y="y",
@@ -424,8 +424,8 @@ def _(fig_scatter, mo):
 
 
 @app.cell
-def _(bpl):
-    spec_from_dict = bpl.PlotSpec.model_validate(
+def _(blt):
+    spec_from_dict = blt.PlotSpec.model_validate(
         {
             "data": {
                 "columns": {
@@ -442,7 +442,7 @@ def _(bpl):
             "theme": "bluesky",
         }
     )
-    fig_roundtrip = bpl.render(spec_from_dict)
+    fig_roundtrip = blt.render(spec_from_dict)
     fig_roundtrip
     return
 
@@ -492,11 +492,11 @@ def _(mo):
 
 
 @app.cell
-def _(MPL_SCRIPT, bpl):
+def _(MPL_SCRIPT, blt):
     from botplotlib.refactor.from_matplotlib import from_matplotlib
 
     spec_refactored = from_matplotlib(MPL_SCRIPT)
-    fig_refactored = bpl.render(spec_refactored)
+    fig_refactored = blt.render(spec_refactored)
     fig_refactored
     return (spec_refactored,)
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -8,7 +8,7 @@ import math
 import random
 from pathlib import Path
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.refactor.from_matplotlib import from_matplotlib
 
 OUT = Path(__file__).parent
@@ -23,7 +23,7 @@ weights = [2.0 + random.gauss(0, 0.6) for _ in range(n)]
 mpg = [45 - 8 * w + random.gauss(0, 2.5) for w in weights]
 origins = random.choices(["USA", "Europe", "Japan"], weights=[4, 3, 3], k=n)
 
-fig_scatter = bpl.scatter(
+fig_scatter = blt.scatter(
     {"weight": weights, "mpg": mpg, "origin": origins},
     x="weight",
     y="mpg",
@@ -46,7 +46,7 @@ for p, m in zip(products, months):
     trend = base[p] + m * (8 if p == "SaaS" else 3 if p == "Hardware" else 5)
     revenue.append(round(trend + random.gauss(0, 6), 1))
 
-fig_line = bpl.line(
+fig_line = blt.line(
     {"month": months, "revenue": revenue, "product": products},
     x="month",
     y="revenue",
@@ -61,7 +61,7 @@ print("  wrote demo_line.svg")
 # ---------------------------------------------------------------------------
 # 3. Bar: "Programming Language Popularity"
 # ---------------------------------------------------------------------------
-fig_bar = bpl.bar(
+fig_bar = blt.bar(
     {
         "language": [
             "Python",
@@ -93,7 +93,7 @@ data_wave = {
 }
 
 for theme_name in ("default", "bluesky", "print", "pdf", "magazine"):
-    fig = bpl.line(
+    fig = blt.line(
         data_wave,
         x="x",
         y="y",
@@ -126,7 +126,7 @@ plt.savefig("old_plot.png")
 """
 
 spec = from_matplotlib(MPL_SCRIPT)
-fig_refactor = bpl.render(spec)
+fig_refactor = blt.render(spec)
 fig_refactor.save_svg(OUT / "demo_refactored.svg")
 print("  wrote demo_refactored.svg  (auto-converted from matplotlib!)")
 

--- a/examples/demo_magazine.py
+++ b/examples/demo_magazine.py
@@ -10,7 +10,7 @@ Then open the generated SVGs in your browser.
 import random
 from pathlib import Path
 
-import botplotlib as bpl
+import botplotlib as blt
 
 OUT = Path(__file__).parent
 random.seed(42)
@@ -18,7 +18,7 @@ random.seed(42)
 # ---------------------------------------------------------------------------
 # Bar chart: magazine-style categorical data
 # ---------------------------------------------------------------------------
-fig_bar = bpl.bar(
+fig_bar = blt.bar(
     {
         "country": ["China", "United States", "India", "Germany", "Japan", "UK"],
         "gdp": [17.96, 25.46, 3.73, 4.26, 4.23, 3.07],
@@ -45,7 +45,7 @@ life_exp = [70 + random.gauss(0, 5) for _ in range(n)]
 gdp_pc = [20 + le * 0.5 + random.gauss(0, 3) for le in life_exp]
 regions = random.choices(["Europe", "Asia", "Americas"], weights=[3, 4, 3], k=n)
 
-fig_scatter = bpl.scatter(
+fig_scatter = blt.scatter(
     {"life_expectancy": life_exp, "gdp_per_capita": gdp_pc, "region": regions},
     x="life_expectancy",
     y="gdp_per_capita",

--- a/examples/refactor_examples/01_scatter_after.py
+++ b/examples/refactor_examples/01_scatter_after.py
@@ -1,11 +1,11 @@
 """botplotlib version: 1 function call. Same result."""
 
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "trial": [1, 2, 3, 4, 5, 6, 7, 8],
     "cm": [2.3, 4.1, 3.5, 6.2, 5.8, 7.1, 8.3, 7.9],
 }
 
-fig = bpl.scatter(data, x="trial", y="cm", title="Experiment Results")
+fig = blt.scatter(data, x="trial", y="cm", title="Experiment Results")
 fig.save_svg("experiment.svg")

--- a/examples/refactor_examples/02_line_after.py
+++ b/examples/refactor_examples/02_line_after.py
@@ -1,11 +1,11 @@
 """botplotlib version: clean spines and grid are the default."""
 
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "year": [2019, 2020, 2021, 2022, 2023, 2024],
     "revenue": [85, 100, 120, 115, 140, 160],
 }
 
-fig = bpl.line(data, x="year", y="revenue", title="Annual Revenue Growth")
+fig = blt.line(data, x="year", y="revenue", title="Annual Revenue Growth")
 fig.save_svg("revenue.svg")

--- a/examples/refactor_examples/03_bar_after.py
+++ b/examples/refactor_examples/03_bar_after.py
@@ -1,13 +1,13 @@
 """botplotlib version: data + one call."""
 
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "lang": ["Python", "JavaScript", "Rust", "Go", "TypeScript"],
     "score": [92, 88, 45, 62, 78],
 }
 
-fig = bpl.bar(
+fig = blt.bar(
     data,
     x="lang",
     y="score",

--- a/examples/refactor_examples/04_publication_after.py
+++ b/examples/refactor_examples/04_publication_after.py
@@ -1,6 +1,6 @@
 """botplotlib version: theme='pdf' handles all publication styling."""
 
-import botplotlib as bpl
+import botplotlib as blt
 
 data = {
     "year": [
@@ -31,7 +31,7 @@ data = {
     ],
 }
 
-fig = bpl.line(
+fig = blt.line(
     data,
     x="year",
     y="anomaly",

--- a/prompts/agent-team-launch-prompt.md
+++ b/prompts/agent-team-launch-prompt.md
@@ -39,7 +39,7 @@ The foundational refactor: replace hardcoded geom dispatch with a plugin archite
 
 4. Change `LayerSpec.geom` from `Literal["scatter", "line", "bar"]` to `str`, validated against the geom registry at compile time. Error message must be specific: "Unknown geom 'xyz'. Available geoms: scatter, line, bar. See AGENTS.md for how to add new geoms."
 
-5. Build waterfall as proof of concept — `botplotlib/geoms/waterfall.py` + `bpl.waterfall()` convenience function + golden baseline tests.
+5. Build waterfall as proof of concept — `botplotlib/geoms/waterfall.py` + `blt.waterfall()` convenience function + golden baseline tests.
 
 6. Run `uv run pytest` — ALL existing tests must pass. Run `uv run ruff check .` and `uv run black --check .`. Fix anything that breaks. Commit.
 
@@ -82,7 +82,7 @@ Tasks:
 
 2. Write tests in `tests/test_json_path.py`: valid round-trip (PlotSpec → JSON → from_json → SVG matches original), missing required fields (clear error), extra fields (ignored gracefully), realistic LLM-generated dict example, malformed types.
 
-3. When done, message the lead with a summary of what was added. The lead will add `bpl.from_json()` and `bpl.from_dict()` re-exports to `__init__.py`.
+3. When done, message the lead with a summary of what was added. The lead will add `blt.from_json()` and `blt.from_dict()` re-exports to `__init__.py`.
 
 4. Run tests, lint, format. Commit.
 

--- a/research/cyborg-extensibility-and-governance.md
+++ b/research/cyborg-extensibility-and-governance.md
@@ -56,7 +56,7 @@ This is the step-by-step that any Claude Code / Codex / Gemini session can follo
 1. Create `botplotlib/geoms/waterfall.py` (or whatever the geom is)
 2. Implement `validate()`, `compile()`, and `default_scales()`
 3. Register the geom name in the geom registry
-4. Add `bpl.waterfall()` convenience function in `_api.py` (thin factory, ~10 lines)
+4. Add `blt.waterfall()` convenience function in `_api.py` (thin factory, ~10 lines)
 5. Write tests with golden SVG baselines
 6. Submit as a single atomic PR
 

--- a/research/toon-and-ai-native-patterns.md
+++ b/research/toon-and-ai-native-patterns.md
@@ -66,7 +66,7 @@ botplotlib's LLM interactions fall into three distinct modes, and TOON's fit dif
 An LLM generates a Python call like:
 
 ```python
-bpl.scatter(df, x="year", y="temp", color="region", title="Temperature Trend", theme="bluesky")
+blt.scatter(df, x="year", y="temp", color="region", title="Temperature Trend", theme="bluesky")
 ```
 
 This is approximately 35–45 tokens. Data is already in a Python variable (`df`) — it never enters the token stream. TOON is not relevant here. This mode is where botplotlib's token efficiency advantage is greatest: a matplotlib-equivalent is 100–150 tokens; botplotlib is 35–45 tokens.
@@ -114,7 +114,7 @@ The savings grow with row count but plateau around 20–25% for columnar data (b
 
 **Do not add TOON as a primary serialization format.** The complexity cost is not justified for botplotlib's dominant use cases (Modes 1 and 2), where data is already out of the token stream.
 
-**Consider a narrow opt-in for Mode 3.** A `spec.to_toon()` method (or a `bpl.dump_toon(spec)` utility) could be offered for users who explicitly want compact portable artifacts with embedded data. This would be clearly documented as an optimization for the archive/transmission use case, not as the default. Implementation would be ~100 lines of Python; no external dependency needed if we hand-roll the encoder (TOON's grammar is simple).
+**Consider a narrow opt-in for Mode 3.** A `spec.to_toon()` method (or a `blt.dump_toon(spec)` utility) could be offered for users who explicitly want compact portable artifacts with embedded data. This would be clearly documented as an optimization for the archive/transmission use case, not as the default. Implementation would be ~100 lines of Python; no external dependency needed if we hand-roll the encoder (TOON's grammar is simple).
 
 **The more important token efficiency work is already done.** botplotlib's Python API is 35–45 tokens for a complete plot. matplotlib is 100–150 tokens. That 3–4x gap is far more impactful than the 20% savings TOON might offer on the data section of a portable spec.
 
@@ -262,7 +262,7 @@ botplotlib should treat MCP-server exposure as a first-class deliverable alongsi
 
 **Rationale:** There is a legitimate use case for compact portable specs — archiving a plot as a self-contained artifact that includes data, storing specs in a repo, or transmitting between agents that don't share a data environment. For 100+ rows of data, TOON would reduce the data section by ~20%.
 
-**What to do:** A `bpl.dump_toon(spec)` function that encodes the columnar DataSpec as TOON arrays and the spec fields as YAML-style key-values. Roughly 100 lines of Python, no dependencies. Clearly scoped as an optimization utility, not a primary format. Parser (`bpl.load_toon(toon_str)`) required alongside encoder.
+**What to do:** A `blt.dump_toon(spec)` function that encodes the columnar DataSpec as TOON arrays and the spec fields as YAML-style key-values. Roughly 100 lines of Python, no dependencies. Clearly scoped as an optimization utility, not a primary format. Parser (`blt.load_toon(toon_str)`) required alongside encoder.
 
 **Priority:** Low. Build the geom registry and MCP server first.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.figure import Figure
 from botplotlib.spec.models import PlotSpec
 from tests.conftest import assert_valid_svg
@@ -13,7 +13,7 @@ from tests.conftest import assert_valid_svg
 
 class TestScatter:
     def test_basic_scatter(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6]},
             x="x",
             y="y",
@@ -23,7 +23,7 @@ class TestScatter:
         assert_valid_svg(svg)
 
     def test_scatter_with_title(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6]},
             x="x",
             y="y",
@@ -32,7 +32,7 @@ class TestScatter:
         assert "My Scatter" in fig.to_svg()
 
     def test_scatter_with_color(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6], "g": ["A", "A", "B"]},
             x="x",
             y="y",
@@ -42,7 +42,7 @@ class TestScatter:
         assert_valid_svg(svg)
 
     def test_scatter_with_theme(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6]},
             x="x",
             y="y",
@@ -52,13 +52,13 @@ class TestScatter:
 
     def test_scatter_with_list_of_dicts(self) -> None:
         data = [{"x": 1, "y": 4}, {"x": 2, "y": 5}, {"x": 3, "y": 6}]
-        fig = bpl.scatter(data, x="x", y="y")
+        fig = blt.scatter(data, x="x", y="y")
         assert_valid_svg(fig.to_svg())
 
 
 class TestLine:
     def test_basic_line(self) -> None:
-        fig = bpl.line(
+        fig = blt.line(
             {"x": [1, 2, 3, 4], "y": [10, 20, 15, 25]},
             x="x",
             y="y",
@@ -66,7 +66,7 @@ class TestLine:
         assert_valid_svg(fig.to_svg())
 
     def test_line_with_groups(self) -> None:
-        fig = bpl.line(
+        fig = blt.line(
             {
                 "x": [1, 2, 3, 4, 1, 2, 3, 4],
                 "y": [10, 20, 15, 25, 8, 18, 12, 22],
@@ -81,7 +81,7 @@ class TestLine:
 
 class TestBar:
     def test_basic_bar(self) -> None:
-        fig = bpl.bar(
+        fig = blt.bar(
             {"category": ["A", "B", "C"], "value": [10, 20, 15]},
             x="category",
             y="value",
@@ -89,7 +89,7 @@ class TestBar:
         assert_valid_svg(fig.to_svg())
 
     def test_bar_with_title(self) -> None:
-        fig = bpl.bar(
+        fig = blt.bar(
             {"category": ["A", "B", "C"], "value": [10, 20, 15]},
             x="category",
             y="value",
@@ -101,7 +101,7 @@ class TestBar:
 class TestPlot:
     def test_layered_plot(self) -> None:
         data = {"x": [1, 2, 3, 4], "y": [10, 20, 15, 25]}
-        fig = bpl.plot(data)
+        fig = blt.plot(data)
         fig.add_line(x="x", y="y")
         fig.add_scatter(x="x", y="y")
         fig.title = "Layered Plot"
@@ -117,13 +117,13 @@ class TestRender:
             layers=[LayerSpec(geom="scatter", x="x", y="y")],
             labels=LabelsSpec(title="From Spec"),
         )
-        fig = bpl.render(spec)
+        fig = blt.render(spec)
         assert "From Spec" in fig.to_svg()
 
 
 class TestSaveSvg:
     def test_save_svg_creates_file(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6]},
             x="x",
             y="y",
@@ -137,7 +137,7 @@ class TestSaveSvg:
 
 class TestReprSvg:
     def test_repr_svg(self) -> None:
-        fig = bpl.scatter(
+        fig = blt.scatter(
             {"x": [1, 2, 3], "y": [4, 5, 6]},
             x="x",
             y="y",

--- a/tests/test_bar_labels.py
+++ b/tests/test_bar_labels.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.compiler.compiler import CompiledPlot, compile_spec
 from botplotlib.geoms.primitives import CompiledBar, CompiledText
 from botplotlib.spec.models import DataSpec, LayerSpec, PlotSpec
@@ -55,7 +55,7 @@ class TestLabelsOffByDefault:
 
 class TestLabelsAppear:
     def test_labels_in_svg(self) -> None:
-        fig = bpl.bar(BAR_DATA, x="category", y="value", labels=True)
+        fig = blt.bar(BAR_DATA, x="category", y="value", labels=True)
         svg = fig.to_svg()
         for val in [10, 50, 200, 5]:
             assert str(val) in svg
@@ -185,7 +185,7 @@ class TestLabelsJsonRoundTrip:
 
 class TestApiConvenience:
     def test_bar_with_labels(self) -> None:
-        fig = bpl.bar(BAR_DATA, x="category", y="value", labels=True)
+        fig = blt.bar(BAR_DATA, x="category", y="value", labels=True)
         svg = fig.to_svg()
         assert "<svg" in svg
         assert "10" in svg

--- a/tests/test_color_map.py
+++ b/tests/test_color_map.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.compiler.accessibility import ContrastError
 from botplotlib.compiler.compiler import compile_spec
 from botplotlib.spec.models import DataSpec, LayerSpec, PlotSpec
@@ -24,7 +24,7 @@ class TestColorMapBar:
     """color_map produces correct fill colors on bar charts."""
 
     def test_custom_colors_in_svg(self) -> None:
-        fig = bpl.bar(
+        fig = blt.bar(
             BAR_DATA,
             x="category",
             y="value",
@@ -38,7 +38,7 @@ class TestColorMapBar:
 
     def test_partial_color_map_falls_back(self) -> None:
         """Only override some categories; the rest get palette colors."""
-        fig = bpl.bar(
+        fig = blt.bar(
             BAR_DATA,
             x="category",
             y="value",
@@ -52,7 +52,7 @@ class TestColorMapBar:
 
     def test_color_map_without_color_param_ignored(self) -> None:
         """color_map without color= grouping doesn't crash."""
-        fig = bpl.bar(
+        fig = blt.bar(
             BAR_DATA,
             x="category",
             y="value",
@@ -64,7 +64,7 @@ class TestColorMapBar:
 
     def test_blt_food_colors(self) -> None:
         """The BLT bar chart with food-appropriate colors."""
-        fig = bpl.bar(
+        fig = blt.bar(
             BLT_DATA,
             x="layer",
             y="size",
@@ -89,7 +89,7 @@ class TestColorMapScatter:
 
     def test_scatter_custom_colors(self) -> None:
         data = {"x": [1, 2, 3], "y": [4, 5, 6], "grp": ["a", "b", "a"]}
-        fig = bpl.scatter(
+        fig = blt.scatter(
             data,
             x="x",
             y="y",
@@ -110,7 +110,7 @@ class TestColorMapLine:
             "y": [1, 2, 3, 3, 2, 1],
             "g": ["a", "a", "a", "b", "b", "b"],
         }
-        fig = bpl.line(
+        fig = blt.line(
             data,
             x="x",
             y="y",

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -638,8 +638,8 @@ plt.scatter([1, 2, 3], [4, 5, 6])
 plt.title("Test")
 """
         result = to_botplotlib_code(code)
-        assert "import botplotlib as bpl" in result
-        assert "bpl.scatter(" in result
+        assert "import botplotlib as blt" in result
+        assert "blt.scatter(" in result
         assert 'title="Test"' in result
 
     def test_line_with_labels(self) -> None:
@@ -651,7 +651,7 @@ plt.xlabel("X Axis")
 plt.ylabel("Y Axis")
 """
         result = to_botplotlib_code(code)
-        assert "bpl.line(" in result
+        assert "blt.line(" in result
         assert 'title="My Line"' in result
         assert 'x_label="X Axis"' in result
         assert 'y_label="Y Axis"' in result
@@ -662,7 +662,7 @@ import matplotlib.pyplot as plt
 plt.bar(["A", "B"], [10, 20])
 """
         result = to_botplotlib_code(code)
-        assert "bpl.bar(" in result
+        assert "blt.bar(" in result
 
     def test_no_plots_returns_comment(self) -> None:
         code = """
@@ -679,7 +679,7 @@ plt.plot([5, 6], [7, 8])
 """
         result = to_botplotlib_code(code)
         assert "PlotSpec" in result
-        assert "bpl.render(spec)" in result
+        assert "blt.render(spec)" in result
 
     def test_custom_figsize_in_code(self) -> None:
         code = """

--- a/tests/test_waterfall.py
+++ b/tests/test_waterfall.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-import botplotlib as bpl
+import botplotlib as blt
 from botplotlib.compiler.compiler import CompiledPlot, compile_spec
 from botplotlib.geoms import get_geom, registered_geoms
 from botplotlib.geoms.primitives import CompiledBar, CompiledText
@@ -43,16 +43,16 @@ class TestWaterfallRegistry:
 
 
 class TestWaterfallAPI:
-    """bpl.waterfall() convenience function works."""
+    """blt.waterfall() convenience function works."""
 
     def test_basic_waterfall(self) -> None:
-        fig = bpl.waterfall(WATERFALL_DATA, x="category", y="amount")
+        fig = blt.waterfall(WATERFALL_DATA, x="category", y="amount")
         svg = fig.to_svg()
         assert "<svg" in svg
         assert "</svg>" in svg
 
     def test_waterfall_with_title(self) -> None:
-        fig = bpl.waterfall(
+        fig = blt.waterfall(
             WATERFALL_DATA,
             x="category",
             y="amount",
@@ -62,7 +62,7 @@ class TestWaterfallAPI:
         assert "Profit Breakdown" in svg
 
     def test_waterfall_with_theme(self) -> None:
-        fig = bpl.waterfall(
+        fig = blt.waterfall(
             WATERFALL_DATA,
             x="category",
             y="amount",
@@ -169,28 +169,28 @@ class TestWaterfallEdgeCases:
 
     def test_all_positive(self) -> None:
         data = {"step": ["A", "B", "C"], "val": [10, 20, 30]}
-        fig = bpl.waterfall(data, x="step", y="val")
+        fig = blt.waterfall(data, x="step", y="val")
         compiled = fig.compiled
         colors = {b.color for b in compiled.bars}
         assert len(colors) == 1  # all same color (positive)
 
     def test_all_negative(self) -> None:
         data = {"step": ["A", "B", "C"], "val": [-10, -20, -30]}
-        fig = bpl.waterfall(data, x="step", y="val")
+        fig = blt.waterfall(data, x="step", y="val")
         compiled = fig.compiled
         colors = {b.color for b in compiled.bars}
         assert len(colors) == 1  # all same color (negative)
 
     def test_single_bar(self) -> None:
         data = {"step": ["Only"], "val": [42]}
-        fig = bpl.waterfall(data, x="step", y="val")
+        fig = blt.waterfall(data, x="step", y="val")
         compiled = fig.compiled
         assert len(compiled.bars) == 1
         assert len(compiled.lines) == 0  # no connectors
 
     def test_zero_value(self) -> None:
         data = {"step": ["A", "B"], "val": [100, 0]}
-        fig = bpl.waterfall(data, x="step", y="val")
+        fig = blt.waterfall(data, x="step", y="val")
         compiled = fig.compiled
         assert len(compiled.bars) == 2
         # Zero-height bar should still render (height = 0)
@@ -206,7 +206,7 @@ class TestWaterfallLabels:
     """Waterfall labels appear and are positioned correctly."""
 
     def test_waterfall_labels_appear(self) -> None:
-        fig = bpl.waterfall(WATERFALL_DATA, x="category", y="amount", labels=True)
+        fig = blt.waterfall(WATERFALL_DATA, x="category", y="amount", labels=True)
         svg = fig.to_svg()
         assert "100" in svg
         assert "-40" in svg


### PR DESCRIPTION
## Summary
- Renames the conventional import alias from `import botplotlib as bpl` to `import botplotlib as blt` across the entire codebase
- 31 files, 199 substitutions, zero functional changes
- Because it's a BLT, not a BPL

## Test plan
- [x] All 389 tests pass
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] Refactor module (`from_matplotlib.py`) now generates `blt.` code
- [x] Refactor tests assert on `blt.scatter(`, `blt.line(`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)